### PR TITLE
Rename next/prev to newer/older in chip gallery.

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,5 @@
+- id: older_page
+  translation: "Older"
+
+- id: newer_page
+  translation: "Newer"

--- a/layouts/partials/post_nav_links_in_section.html
+++ b/layouts/partials/post_nav_links_in_section.html
@@ -2,7 +2,7 @@
   {{- if .Page.PrevInSection -}}
   {{- with .Page.PrevInSection }}
   <a class="prev" href="{{ .Permalink }}">
-    <span class="title">« {{ i18n "prev_page" }}</span>
+    <span class="title">☜ {{ i18n "newer_page" }}</span>
     <br>
     <span>{{- .Name -}}</span>
   </a>
@@ -11,7 +11,7 @@
   {{- if .Page.NextInSection -}}
   {{- with .Page.NextInSection }}
   <a class="next" href="{{ .Permalink }}">
-    <span class="title">{{ i18n "next_page" }} »</span>
+    <span class="title">{{ i18n "older_page" }} ☞</span>
     <br>
     <span>{{- .Name -}}</span>
   </a>


### PR DESCRIPTION
This respects the i18n bits that the old version had.

I tried removing the newer/older text entirely, but I liked this better (this does better with line wraps and long titles).

Also I like the pointing finger better than the angle brackets, but Unicode has lots of arrows...